### PR TITLE
Add Stage1 ICLR rebuttal breakdown skill structure

### DIFF
--- a/rebuttalstudio_skill/SKILL.md
+++ b/rebuttalstudio_skill/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: rebuttalstudio_skill
+description: Multi-stage rebuttal analysis skill for RebuttalStudio. Use when organizing reviewer comments into stage-specific conference workflows, especially stage1 breakdown tasks under conference folders.
+---
+
+# RebuttalStudio Multi-Stage Skill
+
+Follow this dispatcher structure:
+
+1. Identify stage first (for now only `stage1`).
+2. Inside that stage, select conference-specific skill.
+3. Execute the conference skill instructions directly.
+
+## Available stage workflows
+
+- `stage1/iclr/SKILL.md`: Convert raw reviewer feedback into a structured breakdown for rebuttal drafting.
+
+If a requested stage/conference does not exist, stop and ask for missing spec before inventing format.

--- a/rebuttalstudio_skill/stage1/iclr/SKILL.md
+++ b/rebuttalstudio_skill/stage1/iclr/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: stage1-iclr-breakdown
+description: Break down full ICLR reviewer responses into structured rebuttal units. Use when input contains reviewer summary/presentation/contribution/strength/weakness/question text and the goal is to split weaknesses/questions into granular R-style response items while preserving original wording for quoted issues.
+---
+
+# Stage 1 · ICLR Breakdown Skill
+
+Process reviewer text into a strict structure for rebuttal planning.
+
+## Input assumptions
+
+- Input is one reviewer's full text (possibly copied from DOC/DOCX or OpenReview).
+- Sections may include: `summary`, `presentation`, `contribution`, `strength`, `weakness`, `question`.
+- Bullets may contain one or multiple independent concerns.
+
+## Mandatory extraction rules
+
+1. **Summary score only**
+   - Output only the numeric score `3` for summary score field.
+   - Do not infer any other summary rating scale.
+
+2. **Keep original text for unchanged fields**
+   - Preserve `summary` and `strength` exactly as written.
+   - Keep line breaks when possible.
+
+3. **Split weakness/question into atomic issues**
+   - For `weakness` and `question`, split into issue-level items.
+   - One bullet usually maps to one response item, but split further when one bullet contains multiple distinct asks/criticisms.
+   - Each atomic item must be mapped to one response block.
+
+4. **Create response blocks: R1 ... RN**
+   - Use `Response1`, `Response2`, ... in final order.
+   - Each response has:
+     - `title`: short generated subtitle (e.g., "Regarding novelty classification").
+     - `source`: `weakness` or `question`.
+     - `source_id`: `weakness1`, `weakness2`, ... or `question1`, `question2`, ... according to origin after splitting.
+     - `quoted_issue`: exact quoted original text segment (verbatim, wrapped in quotes).
+
+5. **Prefix logic for split issues**
+   - If issue comes from weakness section, use `weaknessN`.
+   - If issue comes from question section, use `questionN`.
+   - Number independently per source type.
+
+## Splitting heuristics
+
+Use these cues to split one bullet into multiple issues:
+
+- Multiple independent requests connected by "and", "also", "in addition", "furthermore".
+- Topic shift inside one bullet (e.g., novelty + experiment setting).
+- Distinct actionable asks (e.g., "clarify theorem" and "add baseline").
+- One concern about claim validity and another about writing/organization.
+
+Do **not** split when sentences elaborate the same single concern.
+
+## Output format
+
+Use this exact skeleton:
+
+```markdown
+# Stage1 ICLR Breakdown
+
+## Meta
+- summary_score: 3
+
+## Preserved Sections
+- summary: |
+  <verbatim summary text>
+- strength: |
+  <verbatim strength text>
+
+## Atomic Issues
+- weakness1: "<verbatim quoted issue>"
+- weakness2: "<verbatim quoted issue>"
+- question1: "<verbatim quoted issue>"
+
+## Responses
+### Response1
+- title: <generated subtitle>
+- source: weakness
+- source_id: weakness1
+- quoted_issue: "<same verbatim text as weakness1>"
+
+### Response2
+- title: <generated subtitle>
+- source: weakness
+- source_id: weakness2
+- quoted_issue: "<same verbatim text as weakness2>"
+
+### Response3
+- title: <generated subtitle>
+- source: question
+- source_id: question1
+- quoted_issue: "<same verbatim text as question1>"
+```
+
+## Quality checklist
+
+Before finalizing, verify:
+
+- `summary_score` is exactly `3`.
+- `summary` and `strength` are unchanged.
+- Every weakness/question atomic issue appears once in `Atomic Issues`.
+- Every atomic issue is linked by exactly one response block.
+- `quoted_issue` text is verbatim.


### PR DESCRIPTION
### Motivation
- Provide a local multi-stage skill to standardize transforming full reviewer responses into atomic rebuttal planning units for ICLR stage1 workflows.
- Ensure automated downstream processing produces consistent Response blocks with verbatim quoted issues and a fixed summary score as required by the breakdown spec.

### Description
- Add a dispatcher skill at `rebuttalstudio_skill/SKILL.md` that routes to stage-specific conference skills (currently `stage1/iclr`).
- Add `rebuttalstudio_skill/stage1/iclr/SKILL.md` that encodes the ICLR stage1 breakdown rules, including a fixed `summary_score: 3`, preservation of `summary` and `strength` verbatim, splitting heuristics for `weakness`/`question`, and the `Response1..N` mapping with `title`, `source`, `source_id`, and `quoted_issue` fields.
- Include an exact output skeleton and a quality checklist in the ICLR skill to enforce format and verbatim quoting requirements.

### Testing
- Created the directory structure with `mkdir -p rebuttalstudio_skill/stage1/iclr` and wrote the two `SKILL.md` files as specified, which produced the files `rebuttalstudio_skill/SKILL.md` and `rebuttalstudio_skill/stage1/iclr/SKILL.md`.
- Verified presence and content of the files using `find rebuttalstudio_skill -maxdepth 4 -type f -print` and `nl -ba rebuttalstudio_skill/SKILL.md && nl -ba rebuttalstudio_skill/stage1/iclr/SKILL.md`, both of which succeeded.
- Ran `ls -la` to inspect the working tree and confirmed the created files are present and readable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a33c355788328babfcf51b16e5f99)