### PR TITLE
Add cross-provider API settings UI and persistence

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -99,7 +99,30 @@ ipcMain.handle('projects:list', async () => listProjects());
 ipcMain.handle('app:settings:get', async () => loadAppSettings());
 ipcMain.handle('app:settings:updateDefaultInterval', async (_event, seconds) => {
   const normalized = normalizeInterval(seconds);
-  return saveAppSettings({ defaultAutosaveIntervalSeconds: normalized });
+  const current = await loadAppSettings();
+  return saveAppSettings({ ...current, defaultAutosaveIntervalSeconds: normalized });
+});
+
+ipcMain.handle('app:api:getSettings', async () => {
+  const settings = await loadAppSettings();
+  return {
+    activeApiProvider: settings.activeApiProvider,
+    apiProfiles: settings.apiProfiles,
+  };
+});
+
+ipcMain.handle('app:api:updateSettings', async (_event, payload) => {
+  const current = await loadAppSettings();
+  const next = {
+    ...current,
+    activeApiProvider: payload?.activeApiProvider || current.activeApiProvider,
+    apiProfiles: payload?.apiProfiles || current.apiProfiles,
+  };
+  const saved = await saveAppSettings(next);
+  return {
+    activeApiProvider: saved.activeApiProvider,
+    apiProfiles: saved.apiProfiles,
+  };
 });
 
 ipcMain.handle('projects:create', async (_event, { projectName, conference, autosaveIntervalSeconds }) => {

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -4,6 +4,8 @@ contextBridge.exposeInMainWorld('studioApi', {
   listProjects: () => ipcRenderer.invoke('projects:list'),
   getAppSettings: () => ipcRenderer.invoke('app:settings:get'),
   updateDefaultInterval: (seconds) => ipcRenderer.invoke('app:settings:updateDefaultInterval', seconds),
+  getApiSettings: () => ipcRenderer.invoke('app:api:getSettings'),
+  updateApiSettings: (payload) => ipcRenderer.invoke('app:api:updateSettings', payload),
   createProject: (payload) => ipcRenderer.invoke('projects:create', payload),
   openProject: (folderName) => ipcRenderer.invoke('projects:open', folderName),
   updateProjectState: (payload) => ipcRenderer.invoke('projects:updateState', payload),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -54,7 +54,7 @@
         </div>
         <div class="topbar-right">
           <button id="newBtn" class="btn">+ New</button>
-          <button id="apiOpenBtn" class="btn">Enter API</button>
+          <button id="apiOpenBtn" class="btn">API Settings</button>
         </div>
       </header>
 
@@ -198,9 +198,38 @@
 
   <!-- API Modal -->
   <div id="apiModal" class="modal-backdrop hidden">
-    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="apiModalTitle">
-      <h3 id="apiModalTitle">Enter API Key</h3>
-      <input id="apiInput" type="password" class="text-input" placeholder="sk-..." />
+    <div class="modal api-modal" role="dialog" aria-modal="true" aria-labelledby="apiModalTitle">
+      <h3 id="apiModalTitle">API Settings</h3>
+
+      <div class="settings-group">
+        <label for="apiProviderSelect">Provider</label>
+        <select id="apiProviderSelect" class="conference-select">
+          <option value="openai">OpenAI</option>
+          <option value="anthropic">Anthropic</option>
+          <option value="gemini">Google Gemini</option>
+          <option value="deepseek">DeepSeek</option>
+          <option value="azureOpenai">Azure OpenAI</option>
+        </select>
+      </div>
+
+      <div class="settings-group">
+        <label for="apiBaseUrlInput">Base URL</label>
+        <input id="apiBaseUrlInput" class="text-input" placeholder="https://api.openai.com/v1" />
+      </div>
+
+      <div class="settings-group">
+        <label for="apiModelInput">Model</label>
+        <input id="apiModelInput" class="text-input" placeholder="gpt-4o-mini" />
+      </div>
+
+      <div class="settings-group">
+        <label for="apiInput">API Key</label>
+        <input id="apiInput" type="password" class="text-input" placeholder="Paste API key" />
+      </div>
+
+      <p id="apiSettingsError" class="error"></p>
+      <p class="muted">Tip: Azure OpenAI usually requires a custom endpoint and deployment name in the model field.</p>
+
       <div class="modal-actions">
         <button id="cancelApiBtn" class="btn">Cancel</button>
         <button id="saveApiBtn" class="btn primary">Save</button>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -902,6 +902,11 @@ select {
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
 }
 
+
+.api-modal {
+  width: min(560px, 94vw);
+}
+
 .modal h3 {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 0.9rem;


### PR DESCRIPTION
### Motivation
- Replace the single, ephemeral "Enter API" key flow with a provider-based API settings model so stage pipelines and local skills can reuse a stable, persisted API profile instead of a single in-memory key. 
- Support mainstream providers (OpenAI, Anthropic, Google Gemini, DeepSeek, Azure OpenAI) and allow per-provider Base URL / Model / API Key so the app is compatible with common deployment patterns. 

### Description
- Add default API profiles, normalization and persistence to app settings in `src/main/projectService.js`, and expose new IPC endpoints `app:api:getSettings` and `app:api:updateSettings` in `src/main/main.js`. 
- Expose the new IPC endpoints to the renderer via `studioApi.getApiSettings` and `studioApi.updateApiSettings` in `src/main/preload.js`. 
- Replace the old single-key modal with an `API Settings` modal in `src/renderer/index.html`, add form fields (Provider, Base URL, Model, API Key) and validation, and implement load/save/render logic in `src/renderer/app.js`. 
- Merge autosave/other settings safely when updating to avoid overwriting API settings, and add a wider modal layout in `src/renderer/styles.css` to accommodate the new form. 

### Testing
- Ran syntax checks: `node -c src/renderer/app.js`, `node -c src/main/main.js`, `node -c src/main/projectService.js`, and `node -c src/main/preload.js` — all succeeded. 
- Performed dependency install with `npm install` which completed successfully. 
- Attempted to launch the app with `npm run start` (Electron) but it failed in the container due to a missing system library (`libatk-1.0.so.0`), which is an environment limitation rather than a code error. 
- Tried a Playwright screenshot validation but Chromium failed to start in this environment (SIGSEGV / headless browser crash), so UI runtime screenshot could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a39646490832894ff725252173530)