### PR TITLE
Improve API settings UX with model detection and provider guidance

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -6,6 +6,7 @@ contextBridge.exposeInMainWorld('studioApi', {
   updateDefaultInterval: (seconds) => ipcRenderer.invoke('app:settings:updateDefaultInterval', seconds),
   getApiSettings: () => ipcRenderer.invoke('app:api:getSettings'),
   updateApiSettings: (payload) => ipcRenderer.invoke('app:api:updateSettings', payload),
+  listProviderModels: (payload) => ipcRenderer.invoke('app:api:listModels', payload),
   createProject: (payload) => ipcRenderer.invoke('projects:create', payload),
   openProject: (folderName) => ipcRenderer.invoke('projects:open', folderName),
   updateProjectState: (payload) => ipcRenderer.invoke('projects:updateState', payload),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -215,11 +215,17 @@
       <div class="settings-group">
         <label for="apiBaseUrlInput">Base URL</label>
         <input id="apiBaseUrlInput" class="text-input" placeholder="https://api.openai.com/v1" />
+        <p id="apiBaseUrlHelp" class="muted"></p>
       </div>
 
       <div class="settings-group">
         <label for="apiModelInput">Model</label>
-        <input id="apiModelInput" class="text-input" placeholder="gpt-4o-mini" />
+        <div class="model-input-row">
+          <input id="apiModelInput" class="text-input" list="apiModelList" placeholder="gpt-4o-mini" />
+          <datalist id="apiModelList"></datalist>
+          <button id="detectModelsBtn" class="btn" type="button">Detect models</button>
+        </div>
+        <p id="apiModelHint" class="muted"></p>
       </div>
 
       <div class="settings-group">
@@ -228,7 +234,7 @@
       </div>
 
       <p id="apiSettingsError" class="error"></p>
-      <p class="muted">Tip: Azure OpenAI usually requires a custom endpoint and deployment name in the model field.</p>
+      <p class="muted">Tip: Google Gemini from AI Studio can use API key only; URL/model can be auto-filled.</p>
 
       <div class="modal-actions">
         <button id="cancelApiBtn" class="btn">Cancel</button>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -978,6 +978,18 @@ select {
   background: var(--hover);
 }
 
+
+.model-input-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.model-input-row .btn {
+  white-space: nowrap;
+}
+
 /* ────────────────────── Sidebar enter/exit animation ────────────────────── */
 @keyframes sidebarSlideIn {
   from {


### PR DESCRIPTION
### Motivation
- Make it easier for users who only have an API key (e.g. Google AI Studio / Gemini) to configure the app without guessing Base URL or model names.
- Provide a quick way to discover available models from providers so users don't need to manually enter model IDs.

### Description
- Add a backend helper `listProviderModels(providerKey, profile)` and an IPC handler `app:api:listModels` that queries provider model endpoints (Gemini via `models?key=...`, OpenAI/DeepSeek `/models`, Azure returns deployment guidance, Anthropic returns common IDs). 
- Expose the new IPC to the renderer via `studioApi.listProviderModels` in `preload.js` and wire a front-end flow that calls it when the user clicks `Detect models` in the API modal. 
- Enhance the API modal UI to include a provider guidance map with sensible `Base URL`/`Model` defaults, an inline help line (`apiBaseUrlHelp`), a `datalist` for model suggestions, a `Detect models` button, and a model hint area; also add CSS for the model input row. 
- Relax/adjust validation and save behavior so provider defaults are used when fields are left empty (and require Base URL only when appropriate), and show contextual hints/errors returned from the model listing call.

### Testing
- Ran static checks: `node --check src/main/main.js` and `node --check src/renderer/app.js`, both succeeded. 
- Attempted a quick headless UI check with a local static server and Playwright, but the local http server process did not remain stable in this environment and Playwright navigation returned `ERR_EMPTY_RESPONSE`, so a screenshot-run could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3bb169788328bc69fc37e3d538cf)