### PR TITLE
Stage1: Add Gemini-based breakdown IPC + editable structured UI

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld('studioApi', {
   getApiSettings: () => ipcRenderer.invoke('app:api:getSettings'),
   updateApiSettings: (payload) => ipcRenderer.invoke('app:api:updateSettings', payload),
   listProviderModels: (payload) => ipcRenderer.invoke('app:api:listModels', payload),
+  runStage1Breakdown: (payload) => ipcRenderer.invoke('app:stage1:breakdown', payload),
   createProject: (payload) => ipcRenderer.invoke('projects:create', payload),
   openProject: (folderName) => ipcRenderer.invoke('projects:open', folderName),
   updateProjectState: (payload) => ipcRenderer.invoke('projects:updateState', payload),

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1100,3 +1100,84 @@ select {
     display: none;
   }
 }
+
+.section-editable {
+  min-height: 40px;
+  white-space: pre-wrap;
+  outline: none;
+}
+
+.section-editable:focus,
+.score-value[contenteditable="true"]:focus,
+.issue-text:focus {
+  box-shadow: inset 0 0 0 1px var(--text-muted);
+  border-radius: 4px;
+}
+
+.section-editable.breakdown-placeholder:empty::before {
+  content: attr(data-placeholder);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.breakdown-output-block .breakdown-section + .breakdown-section {
+  border-top: 1px dashed var(--border);
+}
+
+.issues-grid,
+.responses-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.issue-card,
+.response-card {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px;
+  background: var(--panel);
+}
+
+.issue-id,
+.response-header {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.issue-text {
+  white-space: pre-wrap;
+  min-height: 36px;
+  outline: none;
+}
+
+.response-card label {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin-top: 8px;
+  margin-bottom: 3px;
+}
+
+.response-input,
+.response-textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--panel-muted);
+  color: var(--text);
+  padding: 6px 8px;
+  font-size: 0.82rem;
+}
+
+.response-textarea {
+  min-height: 70px;
+  resize: vertical;
+}
+
+.convert-btn.loading {
+  opacity: 0.75;
+  pointer-events: none;
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic, skill-driven Stage1 breakdown by calling the ICLR `stage1/iclr` skill via the configured Gemini provider so reviewer `content` is parsed by the skill, not only by local regex heuristics. 
- Make the API-produced structured output editable in the UI so users can correct any extraction errors (scores, sections, atomic issues, responses) after the model run.

### Description
- Added a new main-process IPC handler `app:stage1:breakdown` and implemented Gemini invocation helpers `buildStage1IclrPrompt`, `runGeminiStage1Breakdown`, and `normalizeStage1Breakdown` in `src/main/main.js` to call `generateContent` and return a normalized JSON shape with `scores`, `sections`, `atomicIssues`, and `responses`.
- Exposed the new flow to the renderer via `studioApi.runStage1Breakdown` in `src/main/preload.js`.
- Wired the renderer `Break down` action to call the Stage1 API (`runStage1ApiBreakdown`) and populate the breakdown data instead of relying only on local regex parsing in `src/renderer/app.js`.
- Reworked the Stage1 right-panel to render editable score fields, editable section blocks, separated Atomic Issue cards, and editable Response cards with `source`, `source_id`, and `quoted_issue`; added change/input handlers to persist manual edits and keep `state.breakdownData` synced.
- Updated UI styling in `src/renderer/styles.css` for the new editable elements and added the default Gemini model hint to `gemini-3-flash-preview` in `src/renderer/app.js` and `src/main/main.js`.
- Implemented basic error handling for missing API key, empty content, and non-OK Gemini responses and a small JSON-cleanup fallback for code-fenced JSON outputs.

### Testing
- Ran Node syntax checks with `node --check` for `src/main/main.js`, `src/main/preload.js`, and `src/renderer/app.js`, which completed successfully. 
- Performed a raw `curl` request against the `gemini-3-flash-preview:generateContent` endpoint using the supplied API key to validate endpoint compatibility and received a JSON-like candidate payload. 
- Launched a local static server and produced a headless browser screenshot of the updated Stage1 breakdown UI via Playwright to validate layout and editable regions, which succeeded and produced `artifacts/stage1-breakdown-ui.png`.
- Exercised the new renderer flow end-to-end (renderer → `studioApi.runStage1Breakdown` → main → Gemini) during development and handled error cases for missing API settings, with the implemented checks raising user-visible alerts when appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a427bc8888328b95d760449b7e397)