### PR TITLE
Add Stage2 ‘Replied’ UI, refine flow, and Stage2 Gemini skill

### DIFF
--- a/rebuttalstudio_skill/stage2/iclr/SKILL.md
+++ b/rebuttalstudio_skill/stage2/iclr/SKILL.md
@@ -1,0 +1,22 @@
+# Stage2 ICLR Refine Skill
+
+## Goal
+Given a Stage1 atomic issue and a user-provided outline, generate a polished and academically toned rebuttal draft.
+
+## Input
+- response id/title/source/source_id
+- quoted_issue (verbatim)
+- outline (free-form user plan)
+
+## Output
+JSON:
+```json
+{ "draft": "..." }
+```
+
+## Requirements
+1. Keep `quoted_issue` concerns central.
+2. Expand outline into clear academic prose.
+3. Avoid fabricated claims, numbers, experiments, or citations.
+4. Keep tone respectful and constructive.
+5. Produce a concise paragraph-level response suitable as first draft.

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('studioApi', {
   updateApiSettings: (payload) => ipcRenderer.invoke('app:api:updateSettings', payload),
   listProviderModels: (payload) => ipcRenderer.invoke('app:api:listModels', payload),
   runStage1Breakdown: (payload) => ipcRenderer.invoke('app:stage1:breakdown', payload),
+  runStage2Refine: (payload) => ipcRenderer.invoke('app:stage2:refine', payload),
   createProject: (payload) => ipcRenderer.invoke('projects:create', payload),
   openProject: (folderName) => ipcRenderer.invoke('projects:open', folderName),
   updateProjectState: (payload) => ipcRenderer.invoke('projects:updateState', payload),

--- a/src/main/projectService.js
+++ b/src/main/projectService.js
@@ -91,6 +91,7 @@ function createProjectDoc(projectName, conference, autosaveIntervalSeconds) {
     updatedAt: now,
     autosaveIntervalSeconds,
     currentStage: 'Stage1',
+    stage2Replies: {},
   };
 
   STAGE_KEYS.forEach((stageKey) => {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1181,3 +1181,59 @@ select {
   opacity: 0.75;
   pointer-events: none;
 }
+
+.reviewer-input.readonly {
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.stage2-response-card .fixed-issue-meta {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  background: var(--panel-muted);
+  font-size: 0.8rem;
+}
+
+.fixed-issue-quote {
+  margin-top: 6px;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+}
+
+.stage2-tools-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.btn.mini {
+  padding: 4px 8px;
+  font-size: 0.72rem;
+}
+
+.stage2-assets {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.response-asset-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px dashed var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 0.74rem;
+}
+
+.asset-insert-btn {
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--text);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.7rem;
+}


### PR DESCRIPTION
### Motivation
- Provide the second-stage ("Replied") UI so users can expand per-issue outlines into academic replies. 
- Allow authors to insert reusable assets (Markdown tables and OpenReview LaTeX formulas) into outlines as building blocks for replies. 
- Wire a Stage2 backend refine flow that uses the same Gemini-based approach as Stage1 and make Stage2 data persistent per reviewer.

### Description
- Renderer: add Stage2 UI rendering with per-response cards containing fixed issue metadata, editable `outline` and `draft` fields, stage-specific tooling buttons, and UI state toggles; new helpers `getStage2ResponsesForReviewer`, `renderStage2Panel`, `currentStageKey`, and `syncStageUi` were added in `src/renderer/app.js`.
- State & persistence: add `stage2Replies` to the global `state`, load/save `state.currentDoc.stage2Replies` in `queueStateSync` and project load/create paths, and initialize `stage2Replies` in `projectService` project documents (`src/main/projectService.js`).
- Insertion tools: implement table and formula insertion controls that generate Markdown table snippets (user-specified rows/cols) and accept LaTeX formula strings, store them as assets, and allow inserting assets back into an outline (`src/renderer/app.js` + CSS in `src/renderer/styles.css`).
- Stage2 refine API: expose `runStage2Refine` in the preload bridge (`src/main/preload.js`), add an IPC handler `app:stage2:refine` and Gemini prompt/response parsing in `src/main/main.js` with `runGeminiStage2Refine` and `buildStage2IclrPrompt` that expect JSON `{ "draft": "..." }`.
- Skill scaffold: add a reusable Stage2 skill file at `rebuttalstudio_skill/stage2/iclr/SKILL.md` describing input/output and generation requirements.
- UX behavior: convert-button behavior switches label/icon between "Break down" and "Refine" depending on current stage and Stage2 disables editing of the left reviewer input while in refine mode.

### Testing
- Ran `node --check src/renderer/app.js`, `node --check src/main/main.js`, and `node --check src/main/preload.js` and they all succeeded. 
- Ran `npm -s run -q lint` which failed because the repository does not define a `lint` script. 
- Attempted an automated page render + screenshot using a local HTTP server and Playwright but the browser run returned `ERR_EMPTY_RESPONSE` so a visual snapshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a502dfa3883288fd8e73c21466400)