### PR TITLE
Stage 2: Replace prompt-based Insert Table/Code with modals and remove Insert Formula

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -339,6 +339,52 @@
     </div>
   </div>
 
+  <!-- Stage2 Insert Table Modal -->
+  <div id="stage2TableModal" class="modal-backdrop hidden">
+    <div class="modal stage2-insert-modal" role="dialog" aria-modal="true" aria-labelledby="stage2TableModalTitle">
+      <h3 id="stage2TableModalTitle">Insert Table</h3>
+      <div class="settings-group stage2-table-dimensions">
+        <div>
+          <label for="stage2TableRowsInput">Rows</label>
+          <input id="stage2TableRowsInput" type="number" min="1" max="20" class="text-input" value="3" />
+        </div>
+        <div>
+          <label for="stage2TableColsInput">Columns</label>
+          <input id="stage2TableColsInput" type="number" min="1" max="10" class="text-input" value="3" />
+        </div>
+      </div>
+      <div class="modal-actions stage2-table-actions">
+        <button id="stage2TableBuildBtn" class="btn" type="button">Build Grid</button>
+      </div>
+      <div id="stage2TableGrid" class="stage2-table-grid"></div>
+      <p id="stage2TableError" class="error"></p>
+      <div class="modal-actions">
+        <button id="stage2TableCancelBtn" class="btn">Cancel</button>
+        <button id="stage2TableConfirmBtn" class="btn primary">Insert</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Stage2 Insert Code Modal -->
+  <div id="stage2CodeModal" class="modal-backdrop hidden">
+    <div class="modal stage2-insert-modal" role="dialog" aria-modal="true" aria-labelledby="stage2CodeModalTitle">
+      <h3 id="stage2CodeModalTitle">Insert Code</h3>
+      <div class="settings-group">
+        <label for="stage2CodeLanguageInput">Language (optional)</label>
+        <input id="stage2CodeLanguageInput" class="text-input" placeholder="e.g. python" />
+      </div>
+      <div class="settings-group">
+        <label for="stage2CodeContentInput">Code</label>
+        <textarea id="stage2CodeContentInput" class="text-input stage2-code-input" placeholder="Paste your code here..."></textarea>
+      </div>
+      <p id="stage2CodeError" class="error"></p>
+      <div class="modal-actions">
+        <button id="stage2CodeCancelBtn" class="btn">Cancel</button>
+        <button id="stage2CodeConfirmBtn" class="btn primary">Insert</button>
+      </div>
+    </div>
+  </div>
+
   <script src="./app.js"></script>
 </body>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1131,6 +1131,56 @@ select {
   gap: var(--space-2);
 }
 
+
+.stage2-insert-modal {
+  width: min(760px, 92vw);
+}
+
+.stage2-table-dimensions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.stage2-table-actions {
+  justify-content: flex-start;
+}
+
+.stage2-table-grid {
+  max-height: 300px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+  background: var(--panel);
+  margin-bottom: 10px;
+}
+
+.stage2-table-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.stage2-table-row:last-child {
+  margin-bottom: 0;
+}
+
+.stage2-table-cell {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel-muted);
+  color: var(--text);
+  padding: 6px 8px;
+}
+
+.stage2-code-input {
+  min-height: 180px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 /* Stage advance modal */
 .stage-advance-modal {
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
### Motivation
- Improve the Stage 2 (Reply) user experience so right-click insert actions open a proper dialog for entering table or code content instead of using `prompt()` popups. 
- Remove the `Insert Formula` option per UX requirement and keep the flow focused on interactive Table and Code insertion. 
- Allow users to build a small editable table UI, or paste code + language, then insert Markdown-formatted content into the outline and persist via the existing asset mechanism.

### Description
- Replaced the Stage 2 right-click flow so the context menu opens dedicated modals instead of `prompt()` dialogs and removed the formula menu item and hint text; the hint now shows "Insert Table / Code" (changes in `src/renderer/app.js`).
- Added an `Insert Table` modal in `src/renderer/index.html` plus JS (`buildStage2TableGrid`, `buildMarkdownTableFromGrid`, `openStage2TableModal`, etc.) in `src/renderer/app.js` to let users choose rows/cols, build an editable grid, and generate a Markdown table to insert via existing `insertStage2Asset` logic.
- Added an `Insert Code` modal in `src/renderer/index.html` and JS handlers to accept optional language and code content, convert it to a fenced Markdown block, and insert it into the outline via `insertStage2Asset`.
- Added supporting CSS rules in `src/renderer/styles.css` to style the new modals, the table grid, table cells, and code input area so the UI expands/scrolls naturally when content grows.

### Testing
- Ran `node --check src/renderer/app.js` to validate the modified JS syntax and it succeeded.
- Started a local HTTP server and attempted an automated Playwright screenshot to validate the UI, but the headless browser process crashed with a SIGSEGV in the execution environment so no screenshot artifact was produced.
- Performed quick smoke checks in code (context-menu wiring, modal open/close handlers, and Markdown table/code generation logic) via static validation and ensured `insertStage2Asset` is reused for persistence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5feaa7fc832896283846ba25de5e)