### PR TITLE
feat: add per-stage template center with fillable placeholders and AI polish

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -9,6 +9,7 @@ contextBridge.exposeInMainWorld('studioApi', {
   listProviderModels: (payload) => ipcRenderer.invoke('app:api:listModels', payload),
   runStage1Breakdown: (payload) => ipcRenderer.invoke('app:stage1:breakdown', payload),
   runStage2Refine: (payload) => ipcRenderer.invoke('app:stage2:refine', payload),
+  runTemplateRephrase: (payload) => ipcRenderer.invoke('app:template:rephrase', payload),
   createProject: (payload) => ipcRenderer.invoke('projects:create', payload),
   openProject: (folderName) => ipcRenderer.invoke('projects:open', folderName),
   updateProjectState: (payload) => ipcRenderer.invoke('projects:updateState', payload),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -385,6 +385,35 @@
     </div>
   </div>
 
+  <!-- Template Modal -->
+  <div id="templateModal" class="modal-backdrop hidden">
+    <div class="modal template-modal" role="dialog" aria-modal="true" aria-labelledby="templateModalTitle">
+      <h3 id="templateModalTitle">Template Center</h3>
+      <div class="template-layout">
+        <section class="template-left">
+          <div id="templateAudienceTabs" class="template-audience-tabs"></div>
+          <div id="templateTypeList" class="template-type-list"></div>
+        </section>
+        <section class="template-right">
+          <div class="template-preview-header">
+            <h4 id="templatePreviewTitle">Template</h4>
+            <div class="template-actions">
+              <button id="templateRenderCopyBtn" class="btn" title="Render and copy">↗ Render+Copy</button>
+              <button id="templateAiPolishBtn" class="btn" title="AI rephrase">✨ Polish</button>
+            </div>
+          </div>
+          <div id="templateFields" class="template-fields"></div>
+          <textarea id="templateRenderedOutput" class="text-input template-output" readonly
+            placeholder="Rendered template text will appear here..."></textarea>
+          <p id="templateError" class="error"></p>
+        </section>
+      </div>
+      <div class="modal-actions">
+        <button id="closeTemplateBtn" class="btn primary">Close</button>
+      </div>
+    </div>
+  </div>
+
   <script src="./app.js"></script>
 </body>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1588,3 +1588,110 @@ select {
     grid-template-columns: 1fr;
   }
 }
+.sidebar-template-trigger {
+  margin-top: 10px;
+  width: 100%;
+  border: 1px dashed var(--accent);
+  background: color-mix(in srgb, var(--accent-soft) 50%, transparent);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 10px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.sidebar-template-trigger:hover {
+  filter: brightness(1.08);
+}
+
+.sidebar-template-icon {
+  font-size: 1rem;
+}
+
+.sidebar-template-text {
+  text-transform: lowercase;
+  font-family: 'IBM Plex Mono', monospace;
+  letter-spacing: 0.8px;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.template-modal {
+  width: min(1100px, 92vw);
+}
+
+.template-layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 14px;
+  min-height: 460px;
+}
+
+.template-left {
+  border-right: 1px solid var(--border);
+  padding-right: 10px;
+}
+
+.template-audience-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
+.template-audience-tab,
+.template-type-item {
+  border: 1px solid var(--border);
+  background: var(--panel-muted);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.template-audience-tab.active,
+.template-type-item.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.template-type-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.template-preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.template-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.template-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(160px, 1fr));
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.template-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.84rem;
+}
+
+.template-output {
+  min-height: 300px;
+  font-family: 'IBM Plex Mono', monospace;
+  line-height: 1.45;
+}


### PR DESCRIPTION
### Motivation

- Provide a lightweight but visible `template` entry under the stage list so users can quickly insert and customize common messages (e.g., reviewer nudges) per stage. 
- Allow filling small placeholders (e.g., reviewer/submission IDs) and either copy rendered text or ask the app to rephrase/polish via the existing AI backend.

### Description

- Added a `Template Center` UI: a small prominent `template` trigger appended to the stage list and a two-pane modal with audience tabs (Reviewer / Area Chair), template type list, placeholder inputs, rendered output, and action buttons (`Render+Copy` and `✨ Polish`). (files: `src/renderer/index.html`, `src/renderer/styles.css`)
- Implemented client-side template system and UI logic: `TEMPLATE_LIBRARY`, placeholder extraction (`{{...}}`), state `templateUi`, rendering, copy fallback, and modal open/close handlers. (file: `src/renderer/app.js`)
- Added built-in reviewer templates for “催回复” and “催讨论 / Follow up” with `{{reviewerId}}` and `{{submissionId}}` placeholders and default fallback values. (file: `src/renderer/app.js`)
- Integrated AI polish flow: exposed `runTemplateRephrase` in the preload bridge, added IPC handler `app:template:rephrase` in main process, and implemented a Gemini-backed rephrase function that returns JSON `{ "text": "..." }`; front-end calls this to get a polished version and copies it to clipboard. This AI polish currently follows the app's Gemini requirement (same constraint as existing stage APIs). (files: `src/main/preload.js`, `src/main/main.js`, `src/renderer/app.js`)

### Testing

- Ran JS syntax checks with `node --check` on modified files and they passed: `src/renderer/app.js`, `src/main/main.js`, `src/main/preload.js`.
- Attempted an automated screenshot run via Playwright to visually validate the modal, but the browser container could not load the local `file://` path so no screenshot was produced.
- Repository updated and a PR was created for review; no unit tests exist for the UI changes in this repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a69f8f370832887c9e1acfcc82a29)