### PR TITLE
Add Stage3 (First Round) style selection modal and preview workflow

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -339,6 +339,31 @@
     </div>
   </div>
 
+  <!-- Stage3 Style Modal -->
+  <div id="stage3StyleModal" class="modal-backdrop hidden">
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="stage3StyleTitle">
+      <h3 id="stage3StyleTitle">First Round Style</h3>
+      <div class="settings-group">
+        <label for="stage3StyleSelect">Style</label>
+        <select id="stage3StyleSelect" class="text-input">
+          <option value="standard">Standard Style</option>
+        </select>
+      </div>
+      <div id="stage3ColorSection" class="settings-group">
+        <label>Theme Color</label>
+        <div id="stage3PresetColors" class="stage3-palette"></div>
+        <div class="stage3-custom-color-row">
+          <span class="muted">Custom Hex</span>
+          <input id="stage3CustomHexInput" class="text-input" placeholder="#f26921" maxlength="7" />
+        </div>
+      </div>
+      <p id="stage3StyleError" class="error"></p>
+      <div class="modal-actions">
+        <button id="stage3StyleConfirmBtn" class="btn primary">Apply</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Stage2 Insert Table Modal -->
   <div id="stage2TableModal" class="modal-backdrop hidden">
     <div class="modal stage2-insert-modal" role="dialog" aria-modal="true" aria-labelledby="stage2TableModalTitle">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1732,3 +1732,82 @@ select {
   justify-content: center;
 }
 
+
+.stage3-palette {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.stage3-color-dot {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  background: var(--dot);
+  cursor: pointer;
+}
+
+.stage3-color-dot.active {
+  box-shadow: 0 0 0 2px var(--text);
+}
+
+.stage3-color-custom {
+  border: 1px dashed var(--border);
+  background: transparent;
+  border-radius: 999px;
+  padding: 0 10px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.stage3-custom-color-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.stage3-left-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.stage3-reviewer-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 600;
+}
+
+.stage3-issues-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.stage3-issue-pill {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel-muted);
+  color: var(--text-muted);
+  padding: 4px 12px;
+  cursor: pointer;
+}
+
+.stage3-issue-pill.active {
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+.stage3-plan-head {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.stage3-preview-markdown {
+  white-space: pre-wrap;
+  line-height: 1.6;
+  font-size: 0.88rem;
+}

--- a/templates/stage3_styles.json
+++ b/templates/stage3_styles.json
@@ -1,0 +1,16 @@
+{
+  "defaultStyle": "standard",
+  "styles": {
+    "standard": {
+      "label": "Standard Style",
+      "supportsThemeColor": true,
+      "template": {
+        "title": "R{{responseIndex}}: {{responseTitle}}",
+        "quoteLabel": "{{issueTypeLabel}}-{{issueIndex}}:",
+        "quoteContent": "{{quotedIssue}}",
+        "responseLabel": "Response {{issueCode}}:",
+        "responseContent": "{{refinedAnswer}}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a fixed, serializable format for Stage3 (first-round) output so the UI can render a consistent preview style. 
- Let users choose a presentation `style` (default `standard`) and a theme color (7 preset rainbow colors + custom hex) to control Stage3 visual branding. 
- Surface a two-pane Stage3 workflow (left: plan/edit per-response, right: rendered preview) that composes Stage2 refined replies into the first-round rebuttal layout. 
- Persist Stage3 choices and per-response plan drafts so project state restores after reopen. 

### Description
- Add a stage style definition file `templates/stage3_styles.json` that declares the `standard` style schema and placeholder tokens for rendering. 
- Introduce a Stage3 style modal in `src/renderer/index.html` and palette UI plus CSS rules in `src/renderer/styles.css` to show presets and accept a custom `#RRGGBB` entry. 
- Implement style loading (`loadStage3StyleLibrary()`), new state fields (`stage3Settings`, `stage3Drafts`, `stage3Selection`) and preset colors (`STAGE3_PRESET_COLORS`) in `src/renderer/app.js`. 
- Implement Stage3 rendering and interactions in `src/renderer/app.js` including `renderStage3Panels()`, color validation (`normalizeHexColor()`), per-response plan-task editor, response pills, and preview composition that fills `Response Wn/Qn` labels using Stage2 refined text. 
- Persist Stage3 state to project JSON via `queueStateSync()` and restore on project load in `renderWorkspace()`, and change the central convert button to show `Preview` when in Stage3. 

### Testing
- Ran `node --check src/renderer/app.js` and it returned without errors (success). 
- Ran `node --check src/main/projectService.js` and it returned without errors (success). 
- Verified `templates/stage3_styles.json` parses with `node -e "JSON.parse(require('fs').readFileSync('templates/stage3_styles.json','utf8')); console.log('ok')"` (success). 
- Attempted to serve the app and capture a screenshot via Playwright, but navigation failed with `ERR_EMPTY_RESPONSE` in this environment so headless rendering verification was not completed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a76271cfc832889a59fae36b7065c)