### PR TITLE
Refine Stage2 ICLR skill with style rules and opener customization

### DIFF
--- a/rebuttalstudio_skill/stage2/iclr/SKILL.md
+++ b/rebuttalstudio_skill/stage2/iclr/SKILL.md
@@ -1,22 +1,84 @@
+---
+name: stage2-iclr-refine
+description: Refine a Stage2 ICLR rebuttal draft into polished, reviewer-facing prose in the author's style; preserve factual grounding, optionally prepend a courteous opening phrase, and normalize tables/code/formulas into Markdown.
+---
+
 # Stage2 ICLR Refine Skill
 
+## When to use
+Use this skill when you already have:
+- one Stage1 atomic issue (`quoted_issue`), and
+- a Stage2 draft/outline,
+and now need a polished rebuttal paragraph (or short multi-paragraph answer) that sounds respectful, precise, and persuasive.
+
 ## Goal
-Given a Stage1 atomic issue and a user-provided outline, generate a polished and academically toned rebuttal draft.
+Turn a rough draft into a reviewer-ready response that:
+1. directly addresses the reviewer concern,
+2. keeps claims factual and bounded by provided evidence,
+3. matches the user's concise, polite, academically confident writing style,
+4. optionally starts with a customized courteous opener.
 
 ## Input
-- response id/title/source/source_id
-- quoted_issue (verbatim)
-- outline (free-form user plan)
+- `response_id` / `title` / `source` / `source_id` (metadata)
+- `quoted_issue` (verbatim reviewer concern)
+- `draft` or `outline` (user-provided response content)
+- optional style hints from user history (preferred tone, sentence length, verbosity)
 
 ## Output
-JSON:
+Return strict JSON:
+
 ```json
 { "draft": "..." }
 ```
 
-## Requirements
-1. Keep `quoted_issue` concerns central.
-2. Expand outline into clear academic prose.
-3. Avoid fabricated claims, numbers, experiments, or citations.
-4. Keep tone respectful and constructive.
-5. Produce a concise paragraph-level response suitable as first draft.
+## Core writing style rules
+1. **Respect-first opening**: begin with appreciation/acknowledgment before rebuttal substance when appropriate.
+2. **Issue anchoring**: explicitly connect the response to `quoted_issue` in the first 1–2 sentences.
+3. **Novelty articulation**: clearly state what is new, why it matters, and how it differs from prior work.
+4. **No fabrication**: never invent experiments, numbers, citations, or implementation details.
+5. **Constructive tone**: avoid defensive language; prefer collaborative phrasing.
+6. **Concise precision**: short, information-dense paragraphs; avoid repetitive restatement.
+
+## Courtesy opening phrase bank
+When refining, choose **one** opener that best matches the reviewer comment and prepend it naturally.
+Do not stack multiple openers.
+
+- "Thank you for the excellent suggestion."
+- "Thank you for pointing this out."
+- "Thank you for highlighting this important point about [TOPIC]."
+- "We appreciate the opportunity to further articulate the novelty of [METHOD/IDEA]."
+
+### Opener selection guidance (for API-time customization)
+- If reviewer gives actionable improvement advice → prefer "Thank you for the excellent suggestion."
+- If reviewer spots an omission/ambiguity → prefer "Thank you for pointing this out."
+- If reviewer emphasizes significance of a specific dimension → prefer "Thank you for highlighting this important point about [TOPIC]."
+- If reviewer challenges originality/positioning → prefer "We appreciate the opportunity to further articulate the novelty of [METHOD/IDEA]."
+
+## Markdown normalization rules (mandatory)
+If input contains structured content, normalize in final `draft` as follows:
+
+1. **Tables/Charts → Markdown table**
+   - Convert any tabular comparison into GitHub-flavored Markdown table.
+2. **Code → fenced Markdown code block**
+   - Use triple backticks and language tag when known.
+3. **Formula → Markdown math**
+   - Inline math uses `$...$`.
+   - Display math uses `$$...$$` on separate lines.
+
+## Refine workflow
+1. Read `quoted_issue` and identify reviewer intent (clarification / novelty / validity / scope / limitation).
+2. Extract all factual points from `draft`/`outline`; drop unsupported claims.
+3. Select one courtesy opener from the phrase bank.
+4. Rewrite into coherent academic prose:
+   - acknowledgment,
+   - direct answer,
+   - evidence/logic,
+   - forward-looking clarification (if needed).
+5. Normalize any table/code/formula into Markdown format.
+6. Return strict JSON only.
+
+## Hard constraints
+- Do not alter the meaning of user-provided technical claims.
+- Do not introduce new citations unless already provided.
+- Do not over-promise (e.g., "we will definitely" without basis).
+- Keep the final text ready for immediate rebuttal submission editing.


### PR DESCRIPTION
### Motivation
- Convert the minimal Stage2 prompt into a proper Skill spec so the refine step can be triggered and used consistently by the system. 
- Capture the author's preferred rebuttal voice and reusable opening phrases so API-time refinement can prepend a context-appropriate courteous opener. 
- Enforce normalization rules for structured content (tables, code, formulas) so outputs are consistent and downstream-editable. 
- Add a deterministic refine workflow and hard constraints to keep drafts factual and submission-ready.

### Description
- Added YAML frontmatter (`name`/`description`) and expanded `rebuttalstudio_skill/stage2/iclr/SKILL.md` with `When to use`, `Goal`, `Input`, and `Output` sections. 
- Introduced explicit `Core writing style rules` to capture respect-first openings, issue anchoring, novelty articulation, anti-fabrication, constructive tone, and concise precision. 
- Added a `Courtesy opening phrase bank` with API-time `Opener selection guidance` so one customized opener is chosen per refinement. 
- Implemented mandatory `Markdown normalization rules` for tables/charts, code blocks, and formulas, plus a stepwise `Refine workflow` and `Hard constraints` for safe, factual outputs.

### Testing
- Verified system guidance file readability by loading the system skill creator `SKILL.md` with `sed` which completed successfully. 
- Located and enumerated relevant skill files with `rg` and `find` searches to confirm the correct target path `rebuttalstudio_skill/stage2/iclr/SKILL.md`. 
- Printed and inspected the updated `rebuttalstudio_skill/stage2/iclr/SKILL.md` contents with `nl -ba` to validate the new sections and formatting. 
- Attempted to extract opener phrases from the uploaded `Refine.docx` with a Python-based DOCX reader, which failed because the specified file path was not present (`exists False`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a9f4c41c48328ba9a114d344b65bc)