### PR TITLE
Redesign Stage 3 split markdown source + secure OpenReview-like preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "rebuttal-studio",
       "version": "1.0.0",
+      "dependencies": {
+        "dompurify": "^3.3.1",
+        "marked": "^17.0.3"
+      },
       "devDependencies": {
         "electron": "^31.0.2"
       }
@@ -108,6 +112,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -283,6 +294,15 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron": {
       "version": "31.7.7",
@@ -605,6 +625,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.3.tgz",
+      "integrity": "sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/matcher": {

--- a/package.json
+++ b/package.json
@@ -8,5 +8,9 @@
   },
   "devDependencies": {
     "electron": "^31.0.2"
+  },
+  "dependencies": {
+    "dompurify": "^3.3.1",
+    "marked": "^17.0.3"
   }
 }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -120,6 +120,7 @@
               </span>
               <span class="convert-label">Auto Fit</span>
             </button>
+            <p id="stage3ThemeNotice" class="stage3-theme-notice hidden" role="status" aria-live="polite"></p>
           </div>
 
           <!-- Right panel: Structured Breakdown (ICLR format) -->
@@ -480,6 +481,8 @@
     </div>
   </div>
 
+  <script src="../../node_modules/marked/lib/marked.umd.js"></script>
+  <script src="../../node_modules/dompurify/dist/purify.min.js"></script>
   <script src="./app.js"></script>
 </body>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1840,3 +1840,84 @@ select {
   line-height: 1.6;
   font-size: 0.88rem;
 }
+
+.stage3-theme-notice {
+  max-width: 92px;
+  font-size: 0.72rem;
+  line-height: 1.35;
+  color: var(--text-muted);
+  text-align: center;
+  margin: 0;
+}
+
+.stage3-source-editor {
+  min-height: 420px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  white-space: pre;
+  overflow: auto;
+}
+
+.stage3-preview-host {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel-muted);
+  padding: 16px;
+}
+
+.stage3-openreview-preview {
+  --stage3-theme-color: #f26921;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text);
+}
+
+.stage3-openreview-preview h1,
+.stage3-openreview-preview h2,
+.stage3-openreview-preview h3,
+.stage3-openreview-preview h4,
+.stage3-openreview-preview h5,
+.stage3-openreview-preview h6 {
+  margin: 1.1em 0 0.55em;
+  color: var(--stage3-theme-color);
+  font-weight: 600;
+}
+
+.stage3-openreview-preview p,
+.stage3-openreview-preview ul,
+.stage3-openreview-preview ol,
+.stage3-openreview-preview pre,
+.stage3-openreview-preview table,
+.stage3-openreview-preview blockquote {
+  margin: 0.7em 0;
+}
+
+.stage3-openreview-preview a {
+  color: var(--stage3-theme-color);
+  text-decoration: underline;
+}
+
+.stage3-openreview-preview blockquote {
+  border-left: 3px solid var(--stage3-theme-color);
+  padding: 0.2em 0 0.2em 0.9em;
+  color: var(--text-muted);
+}
+
+.stage3-openreview-preview code {
+  font-family: 'IBM Plex Mono', monospace;
+  background: rgba(0, 0, 0, 0.08);
+  padding: 0.1em 0.28em;
+  border-radius: 4px;
+}
+
+[data-theme="dark"] .stage3-openreview-preview code {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.stage3-openreview-preview mark,
+.stage3-openreview-preview .accent {
+  background: color-mix(in srgb, var(--stage3-theme-color) 16%, transparent);
+  color: inherit;
+}


### PR DESCRIPTION
### Motivation
- Stage 3 previously mixed raw source and preview behavior and auto-rendered on edit, producing incorrect UX and unsafe HTML handling.  
- The goal was to provide a true split view with an editable Markdown source on the left and a read-only sanitized preview on the right, matching OpenReview comment rendering.  
- Theme color changes must only apply after an explicit re-preview action and notify the user accordingly.

### Description
- Reworked Stage 3 UI and state in `src/renderer/app.js` to introduce a left `textarea` Markdown source editor and a right read-only preview host, with new draft fields persisted in `state.stage3Drafts` such as `markdownSource`, `renderedHtml`, and `renderedThemeColor`.  
- Implemented an explicit preview pipeline via the new `renderStage3Preview()` and `parseAndSanitizeStage3Markdown()` functions using `marked` to parse Markdown/HTML and `DOMPurify` to sanitize output before insertion.  
- Added a small notification flow (`showStage3ThemeNotice`) so applying styles shows the message `Theme updated successfully. Please re-preview.` and does not auto-refresh the preview until `Preview` is clicked.  
- Updated renderer HTML and CSS (`src/renderer/index.html`, `src/renderer/styles.css`) to load `marked` and `DOMPurify`, add the theme notice element, and apply OpenReview-like typography/spacing and theme-aware accent styles; added `dompurify` and `marked` as dependencies in `package.json`.

### Testing
- Ran a JavaScript syntax check with `node --check src/renderer/app.js`, which succeeded.  
- Installed and verified parser/sanitizer packages with `npm install marked dompurify` and served the app using `python -m http.server 4173 -d /workspace/RebuttalStudio` to validate assets loading, which succeeded.  
- Captured a UI verification screenshot using a Playwright run against `http://127.0.0.1:4173/src/renderer/index.html`, which produced the artifact and confirmed the split layout and preview behavior.  
- No automated unit tests existed for this UI work; the above runtime checks succeeded and the preview/rendering behavior was exercised manually via the served UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b20632c188328b72f0ec6a01362e5)